### PR TITLE
populate registration fields

### DIFF
--- a/src/logistration/RegistrationPage.jsx
+++ b/src/logistration/RegistrationPage.jsx
@@ -125,6 +125,12 @@ class RegistrationPage extends React.Component {
       });
       return false;
     }
+    if (this.props.thirdPartyAuthContext.pipelineUserDetails !== nextProps.thirdPartyAuthContext.pipelineUserDetails) {
+      this.setState({
+        ...nextProps.thirdPartyAuthContext.pipelineUserDetails,
+      });
+      return false;
+    }
     return true;
   }
 
@@ -595,6 +601,7 @@ RegistrationPage.defaultProps = {
     finishAuthUrl: null,
     providers: [],
     secondaryProviders: [],
+    pipelineUserDetails: null,
   },
   formData: null,
   validations: null,

--- a/src/logistration/data/service.js
+++ b/src/logistration/data/service.js
@@ -1,4 +1,4 @@
-import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+import { camelCaseObject, convertKeyNames, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import querystring from 'querystring';
 
@@ -62,7 +62,7 @@ export async function getThirdPartyAuthContext(urlParams) {
       throw (e);
     });
   return {
-    thirdPartyAuthContext: camelCaseObject(data),
+    thirdPartyAuthContext: camelCaseObject(convertKeyNames(data, { fullname: 'name' })),
   };
 }
 

--- a/src/logistration/tests/RegistrationPage.test.jsx
+++ b/src/logistration/tests/RegistrationPage.test.jsx
@@ -272,6 +272,24 @@ describe('./RegistrationPage.js', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('tests shouldComponentUpdate with pipeline user data', () => {
+    const nextProps = {
+      validations: null,
+      thirdPartyAuthContext: {
+        pipelineUserDetails: {
+          name: 'test',
+          email: 'test@example.com',
+          username: 'test-username',
+        },
+      },
+    };
+
+    const root = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+
+    const shouldUpdate = root.find('RegistrationPage').instance().shouldComponentUpdate(nextProps);
+    expect(shouldUpdate).toBe(false);
+  });
+
   it('should match url after redirection', () => {
     const dasboardUrl = 'http://test.com/testing-dashboard/';
     store = mockStore({


### PR DESCRIPTION
When registering via SSO, populate registration fields with user data acquired from the social auth pipeline.

[VAN-238](https://openedx.atlassian.net/browse/VAN-238)