### PR TITLE
VAN-304: update alert link class

### DIFF
--- a/src/logistration/_style.scss
+++ b/src/logistration/_style.scss
@@ -14,6 +14,16 @@ $microsoft-focus-black: #000;
 $apple-black: #000000;
 $apple-focus-black: $apple-black;
 
+.alert-link {
+  font-weight: normal;
+  text-decoration: underline;
+  color: #0075b4 !important;
+
+  &:hover {
+    color: #065683 !important;
+  }
+}
+
 .logistration-header {
   border-bottom: 1px solid #e7e7e7;
   height: 3.75rem;


### PR DESCRIPTION
UX has requested blue underlined links and I have update the <Alert.Link> class .alert-link to reflect this change

Before:
<img width="577" alt="Screenshot 2021-01-25 at 4 34 05 PM" src="https://user-images.githubusercontent.com/40633976/105701074-956b4600-5f2b-11eb-891c-6545e218c5bf.png">

After:
<img width="577" alt="Screenshot 2021-01-25 at 4 33 52 PM" src="https://user-images.githubusercontent.com/40633976/105701061-92705580-5f2b-11eb-923e-9b16cffb866c.png">
